### PR TITLE
Do not reuse the same request state for multi-send messages

### DIFF
--- a/include/oomph/communicator.hpp
+++ b/include/oomph/communicator.hpp
@@ -220,7 +220,7 @@ class communicator
     }
 
     template<typename T>
-    [[nodiscard]] send_request_vector send_multi(
+    send_request_vector send_multi(
         message_buffer<T> const& msg,
         std::vector<rank_type> const& neighs, tag_type tag)
     {

--- a/include/oomph/request.hpp
+++ b/include/oomph/request.hpp
@@ -46,6 +46,8 @@ class send_request
     void wait();
 };
 
+using send_request_vector = std::vector<send_request> ;
+
 class recv_request
 {
   private:
@@ -78,5 +80,7 @@ class recv_request
     void wait();
     bool cancel();
 };
+
+using recv_request_vector = std::vector<recv_request>;
 
 } // namespace oomph

--- a/test/test_cancel.cpp
+++ b/test/test_cancel.cpp
@@ -30,7 +30,7 @@ test_1(oomph::communicator& comm, unsigned int size, int thread_id = 0)
         EXPECT_EQ(comm.scheduled_recvs(), 0);
 
 
-        auto result = comm.send_multi(msg, dsts, 42 + 42 + thread_id);
+        comm.send_multi(msg, dsts, 42 + 42 + thread_id);
         comm.wait_all();
 
         EXPECT_EQ(comm.scheduled_sends(), 0);

--- a/test/test_cancel.cpp
+++ b/test/test_cancel.cpp
@@ -103,7 +103,7 @@ test_2(oomph::communicator& comm, unsigned int size, int thread_id = 0)
         EXPECT_EQ(comm.scheduled_sends(), 0);
         EXPECT_EQ(comm.scheduled_recvs(), 0);
 
-        auto result = comm.send_multi(msg, dsts, 42 + 42 + thread_id);
+        comm.send_multi(msg, dsts, 42 + 42 + thread_id);
         comm.wait_all();
 
         EXPECT_EQ(comm.scheduled_sends(), 0);

--- a/test/test_cancel.cpp
+++ b/test/test_cancel.cpp
@@ -29,7 +29,9 @@ test_1(oomph::communicator& comm, unsigned int size, int thread_id = 0)
         EXPECT_EQ(comm.scheduled_sends(), 0);
         EXPECT_EQ(comm.scheduled_recvs(), 0);
 
-        comm.send_multi(msg, dsts, 42 + 42 + thread_id).wait();
+
+        auto result = comm.send_multi(msg, dsts, 42 + 42 + thread_id);
+        comm.wait_all();
 
         EXPECT_EQ(comm.scheduled_sends(), 0);
         EXPECT_EQ(comm.scheduled_recvs(), 0);
@@ -101,7 +103,8 @@ test_2(oomph::communicator& comm, unsigned int size, int thread_id = 0)
         EXPECT_EQ(comm.scheduled_sends(), 0);
         EXPECT_EQ(comm.scheduled_recvs(), 0);
 
-        comm.send_multi(msg, dsts, 42 + 42 + thread_id).wait();
+        auto result = comm.send_multi(msg, dsts, 42 + 42 + thread_id);
+        comm.wait_all();
 
         EXPECT_EQ(comm.scheduled_sends(), 0);
         EXPECT_EQ(comm.scheduled_recvs(), 0);

--- a/test/test_send_multi.cpp
+++ b/test/test_send_multi.cpp
@@ -47,7 +47,8 @@ TEST_F(mpi_test_fixture, send_multi)
         init_msg(msg);
         std::vector<int> dsts(comm.size() - 1);
         for (int i = 1; i < comm.size(); ++i) dsts[i - 1] = i;
-        comm.send_multi(msg, dsts, 42).wait();
+        auto result = comm.send_multi(msg, dsts, 42);
+        comm.wait_all();
     }
     else
     {

--- a/test/test_send_multi.cpp
+++ b/test/test_send_multi.cpp
@@ -47,7 +47,7 @@ TEST_F(mpi_test_fixture, send_multi)
         init_msg(msg);
         std::vector<int> dsts(comm.size() - 1);
         for (int i = 1; i < comm.size(); ++i) dsts[i - 1] = i;
-        auto result = comm.send_multi(msg, dsts, 42);
+        comm.send_multi(msg, dsts, 42);
         comm.wait_all();
     }
     else


### PR DESCRIPTION
libfabric backend requires each request to be unique and
reusing the same request_state object for multiple sends
to different ranks causes problems.

send_multi now returns a vector of requests instead of a single one