### PR TITLE
remove wait_all in communicator destructor

### DIFF
--- a/src/src.cpp
+++ b/src/src.cpp
@@ -88,7 +88,6 @@ communicator::~communicator()
 {
     if (m_impl)
     {
-        wait_all();
 #if OOMPH_ENABLE_BARRIER
         get_comm_set(m_impl->m_context).erase(m_impl);
 #endif // OOMPH_ENABLE_BARRIER


### PR DESCRIPTION
This should not be done. If the user wants to close the application, we cannot hang.