### PR TITLE
Add function to return transport specific options

### DIFF
--- a/include/oomph/context.hpp
+++ b/include/oomph/context.hpp
@@ -83,6 +83,8 @@ class context
 
     communicator get_communicator();
 
+    const char *get_transport_option(const std::string &opt);
+
   private:
     detail::message_buffer make_buffer_core(std::size_t size);
     detail::message_buffer make_buffer_core(void* ptr, std::size_t size);

--- a/src/mpi/context.hpp
+++ b/src/mpi/context.hpp
@@ -47,6 +47,7 @@ class context_impl : public context_base
     void  lock(communicator::rank_type r) { m_rma_context.lock(r); }
 
     communicator_impl* get_communicator();
+    const char *get_transport_option(const std::string &opt);
 };
 
 template<>

--- a/src/mpi/src.cpp
+++ b/src/mpi/src.cpp
@@ -22,6 +22,15 @@ context_impl::get_communicator()
     return comm;
 }
 
+const char *context_impl::get_transport_option(const std::string &opt) {
+    if (opt == "name") {
+        return "mpi";
+    }
+    else {
+        return "unspecified";
+    }
+}
+
 //send_channel_base::send_channel_base(communicator& comm, std::size_t size, std::size_t T_size,
 //    communicator::rank_type dst, communicator::tag_type tag, std::size_t levels)
 //: m_impl(comm.m_impl, size, T_size, dst, tag, levels)

--- a/src/src.cpp
+++ b/src/src.cpp
@@ -66,6 +66,11 @@ context::get_communicator()
     return {m->get_communicator()};
 }
 
+const char *context::get_transport_option(const std::string &opt)
+{
+    return m->get_transport_option(opt);
+}
+
 ///////////////////////////////
 // communicator              //
 ///////////////////////////////

--- a/src/ucx/context.hpp
+++ b/src/ucx/context.hpp
@@ -146,6 +146,7 @@ class context_impl : public context_base
     auto& get_heap() noexcept { return m_heap; }
 
     communicator_impl* get_communicator();
+    const char *get_transport_option(const std::string &opt);
 };
 
 template<>

--- a/src/ucx/src.cpp
+++ b/src/ucx/src.cpp
@@ -95,6 +95,15 @@ context_impl::~context_impl()
     MPI_Barrier(m_mpi_comm);
 }
 
+const char *context_impl::get_transport_option(const std::string &opt) {
+    if (opt == "name") {
+        return "ucx";
+    }
+    else {
+        return "unspecified";
+    }
+}
+
 } // namespace oomph
 
 #include "../src.cpp"


### PR DESCRIPTION
This is useful when benchmarking/debugging to output a string that can be defined on a per transport level that might have been set via a command line option or env var

Currently the mpi/ucx backends only report their name, and return "unspecified" for all other queries, but the libfabric backend can be run with several environment vars set which affect how endpoints are configured and how locking/progress/other things are configured.

A benchmark/test can print out data regarding these options, by calling `get_transport_option("identifier")` and the transport layer can return something relevant.
