### PR TITLE
Benchmark Output

### DIFF
--- a/benchmarks/bench_p2p_bi_cb_avail_mt.cpp
+++ b/benchmarks/bench_p2p_bi_cb_avail_mt.cpp
@@ -15,6 +15,9 @@
 #include "./utils.hpp"
 #include <vector>
 
+const char *syncmode = "callback";
+const char *waitmode = "avail";
+
 int
 main(int argc, char** argv)
 {
@@ -176,10 +179,24 @@ main(int argc, char** argv)
 
         if (thread_id == 0 && rank == 0)
         {
-            const auto t = t1.toc();
+            const auto t = t1.stoc();
+            double bw = ((double)niter*size*buff_size)/t;
+            // clang-format off
             std::cout << "time:                   " << t / 1000000 << "s\n";
-            std::cout << "final MB/s:             " << (niter * size * (double)buff_size) / t
-                      << std::endl;
+            std::cout << "final MB/s: " << bw << "\n";
+            std::cout << "CSVData"
+                      << ", niter, " << niter
+                      << ", buff_size, " << buff_size
+                      << ", inflight, " << inflight
+                      << ", num_threads, " << num_threads
+                      << ", syncmode, " << syncmode
+                      << ", waitmode, " << waitmode
+                      << ", transport, " << ctxt.get_transport_option("name")
+                      << ", BW MB/s, " << bw
+                      << ", progress, " << ctxt.get_transport_option("progress")
+                      << ", endpoint, " << ctxt.get_transport_option("endpoint")
+                      << "\n";
+            // clang-format on
         }
 
         b();

--- a/benchmarks/bench_p2p_bi_cb_wait_mt.cpp
+++ b/benchmarks/bench_p2p_bi_cb_wait_mt.cpp
@@ -15,6 +15,9 @@
 #include "./utils.hpp"
 #include <vector>
 
+const char *syncmode = "callback";
+const char *waitmode = "wait";
+
 int
 main(int argc, char** argv)
 {
@@ -158,10 +161,24 @@ main(int argc, char** argv)
 
         if (thread_id == 0 && rank == 0)
         {
-            const auto t = t1.toc();
+            const auto t = t1.stoc();
+            double bw = ((double)niter*size*buff_size)/t;
+            // clang-format off
             std::cout << "time:                   " << t / 1000000 << "s\n";
-            std::cout << "final MB/s:             " << (niter * size * (double)buff_size) / t
-                      << std::endl;
+            std::cout << "final MB/s: " << bw << "\n";
+            std::cout << "CSVData"
+                      << ", niter, " << niter
+                      << ", buff_size, " << buff_size
+                      << ", inflight, " << inflight
+                      << ", num_threads, " << num_threads
+                      << ", syncmode, " << syncmode
+                      << ", waitmode, " << waitmode
+                      << ", transport, " << ctxt.get_transport_option("name")
+                      << ", BW MB/s, " << bw
+                      << ", progress, " << ctxt.get_transport_option("progress")
+                      << ", endpoint, " << ctxt.get_transport_option("endpoint")
+                      << "\n";
+            // clang-format on
         }
 
         b();

--- a/benchmarks/bench_p2p_bi_ft_avail_mt.cpp
+++ b/benchmarks/bench_p2p_bi_ft_avail_mt.cpp
@@ -15,6 +15,9 @@
 #include "./utils.hpp"
 #include <vector>
 
+const char *syncmode = "future";
+const char *waitmode = "avail";
+
 int
 main(int argc, char** argv)
 {
@@ -157,10 +160,24 @@ main(int argc, char** argv)
 
         if (thread_id == 0 && rank == 0)
         {
-            const auto t = t1.toc();
+            const auto t = t1.stoc();
+            double bw = ((double)niter*size*buff_size)/t;
+            // clang-format off
             std::cout << "time:                   " << t / 1000000 << "s\n";
-            std::cout << "final MB/s:             " << (niter * size * (double)buff_size) / t
-                      << std::endl;
+            std::cout << "final MB/s: " << bw << "\n";
+            std::cout << "CSVData"
+                      << ", niter, " << niter
+                      << ", buff_size, " << buff_size
+                      << ", inflight, " << inflight
+                      << ", num_threads, " << num_threads
+                      << ", syncmode, " << syncmode
+                      << ", waitmode, " << waitmode
+                      << ", transport, " << ctxt.get_transport_option("name")
+                      << ", BW MB/s, " << bw
+                      << ", progress, " << ctxt.get_transport_option("progress")
+                      << ", endpoint, " << ctxt.get_transport_option("endpoint")
+                      << "\n";
+            // clang-format on
         }
 
         b();

--- a/benchmarks/bench_p2p_bi_ft_wait_mt.cpp
+++ b/benchmarks/bench_p2p_bi_ft_wait_mt.cpp
@@ -15,6 +15,9 @@
 #include "./utils.hpp"
 #include <vector>
 
+const char *syncmode = "future";
+const char *waitmode = "wait";
+
 int
 main(int argc, char** argv)
 {
@@ -115,7 +118,7 @@ main(int argc, char** argv)
 #ifdef OOMPH_BENCHMARKS_MT
 #pragma omp barrier
 #endif
-	    
+
             ///* wait for all */
             //for (int j = 0; j < inflight; j++)
             //{
@@ -128,10 +131,24 @@ main(int argc, char** argv)
 
         if (thread_id == 0 && rank == 0)
         {
-            const auto t = t1.toc();
+            const auto t = t1.stoc();
+            double bw = ((double)niter*size*buff_size)/t;
+            // clang-format off
             std::cout << "time:                   " << t / 1000000 << "s\n";
-            std::cout << "final MB/s:             " << (niter * size * (double)buff_size) / t
-                      << std::endl;
+            std::cout << "final MB/s: " << bw << "\n";
+            std::cout << "CSVData"
+                      << ", niter, " << niter
+                      << ", buff_size, " << buff_size
+                      << ", inflight, " << inflight
+                      << ", num_threads, " << num_threads
+                      << ", syncmode, " << syncmode
+                      << ", waitmode, " << waitmode
+                      << ", transport, " << ctxt.get_transport_option("name")
+                      << ", BW MB/s, " << bw
+                      << ", progress, " << ctxt.get_transport_option("progress")
+                      << ", endpoint, " << ctxt.get_transport_option("endpoint")
+                      << "\n";
+            // clang-format on
         }
     }
 

--- a/include/oomph/context.hpp
+++ b/include/oomph/context.hpp
@@ -83,6 +83,8 @@ class context
 
     communicator get_communicator();
 
+    const char *get_transport_option(const std::string &opt);
+
   private:
     detail::message_buffer make_buffer_core(std::size_t size);
     detail::message_buffer make_buffer_core(void* ptr, std::size_t size);

--- a/src/mpi/context.hpp
+++ b/src/mpi/context.hpp
@@ -47,6 +47,7 @@ class context_impl : public context_base
     void  lock(communicator::rank_type r) { m_rma_context.lock(r); }
 
     communicator_impl* get_communicator();
+    const char *get_transport_option(const std::string &opt);
 };
 
 template<>

--- a/src/mpi/src.cpp
+++ b/src/mpi/src.cpp
@@ -22,6 +22,15 @@ context_impl::get_communicator()
     return comm;
 }
 
+const char *context_impl::get_transport_option(const std::string &opt) {
+    if (opt == "name") {
+        return "mpi";
+    }
+    else {
+        return "unspecified";
+    }
+}
+
 //send_channel_base::send_channel_base(communicator& comm, std::size_t size, std::size_t T_size,
 //    communicator::rank_type dst, communicator::tag_type tag, std::size_t levels)
 //: m_impl(comm.m_impl, size, T_size, dst, tag, levels)

--- a/src/src.cpp
+++ b/src/src.cpp
@@ -66,6 +66,11 @@ context::get_communicator()
     return {m->get_communicator()};
 }
 
+const char *context::get_transport_option(const std::string &opt)
+{
+    return m->get_transport_option(opt);
+}
+
 ///////////////////////////////
 // communicator              //
 ///////////////////////////////

--- a/src/ucx/context.hpp
+++ b/src/ucx/context.hpp
@@ -146,6 +146,7 @@ class context_impl : public context_base
     auto& get_heap() noexcept { return m_heap; }
 
     communicator_impl* get_communicator();
+    const char *get_transport_option(const std::string &opt);
 };
 
 template<>

--- a/src/ucx/src.cpp
+++ b/src/ucx/src.cpp
@@ -95,6 +95,15 @@ context_impl::~context_impl()
     MPI_Barrier(m_mpi_comm);
 }
 
+const char *context_impl::get_transport_option(const std::string &opt) {
+    if (opt == "name") {
+        return "ucx";
+    }
+    else {
+        return "unspecified";
+    }
+}
+
 } // namespace oomph
 
 #include "../src.cpp"


### PR DESCRIPTION
This adds some extra output to the benchmarks. For example, a libfabric run produces
```
CSVData, niter, 12745, buff_size, 1000000, inflight, 100, num_threads, 4, syncmode, future, waitmode, avail, transport, libfabric, BW MB/s, 2465.96, progress, auto, endpoint, threadlocal
```
Which shows all the info needed for plotting in a single line - which in turn makes extraction of plot data a single grep for CSVData in alll the output files and there is no need to parse the directory names as well as output. This makes use / depends on PR #25 to output some options that can be set when launching a benchmark 
For example, 
```
LIBFABRIC_ENDPOINT_TYPE=threadlocal OMP_NUM_THREADS=4 mpiexec -n 2 /home/biddisco/build/oomph/benchmarks/bench_p2p_bi_ft_avail_mt_libfabric 5000 1000000 100
```
The benchmark can query the transport layer and print out extra stuff.