### PR TITLE
fix OOMPH_ANY_SOURCE for MPI backend

### DIFF
--- a/src/communicator_base.hpp
+++ b/src/communicator_base.hpp
@@ -14,6 +14,8 @@
 
 namespace oomph
 {
+#define OOMPH_ANY_SOURCE (int)-1
+
 template<typename Communicator>
 class communicator_base
 {

--- a/src/mpi/communicator.hpp
+++ b/src/mpi/communicator.hpp
@@ -52,6 +52,7 @@ class communicator_impl : public communicator_base<communicator_impl>
     {
         MPI_Request  r;
         device_guard dg(ptr);
+        if(OOMPH_ANY_SOURCE == src) src = MPI_ANY_SOURCE;
         OOMPH_CHECK_MPI_RESULT(MPI_Irecv(dg.data(), size, MPI_BYTE, src, tag, mpi_comm(), &r));
         return {r};
     }

--- a/src/ucx/endpoint.hpp
+++ b/src/ucx/endpoint.hpp
@@ -16,8 +16,6 @@
 
 namespace oomph
 {
-#define OOMPH_ANY_SOURCE (int)-1
-
 struct endpoint_t
 {
     using rank_type = communicator::rank_type;


### PR DESCRIPTION
OOMPH_ANY_SOURCE must be translated to MPI_ANY_SOURCE in the MPI backend