### PR TITLE
Build for Mac

### DIFF
--- a/test/test_locality.cpp
+++ b/test/test_locality.cpp
@@ -17,6 +17,11 @@
 #include <limits.h>
 #include <cstring>
 
+
+#ifdef __APPLE__
+#define HOST_NAME_MAX _POSIX_HOST_NAME_MAX
+#endif
+
 // test locality by collecting all local ranks
 TEST_F(mpi_test_fixture, locality_enumerate)
 {


### PR DESCRIPTION
Update submodule `hwmalloc` with new stub of `libnuma`, because this dependency is not available on Mac.
Also, add posix macro not available on Mac.