### PR TITLE
Fix compilation of libfabric backend with Boost 1.87.0 and newer

### DIFF
--- a/src/libfabric/controller_base.hpp
+++ b/src/libfabric/controller_base.hpp
@@ -482,8 +482,8 @@ class controller_base
                 debug::dec<>(recv_deletes_), "deletes error",
                 debug::dec<>(messages_handled_ - recv_deletes_)));
 
-        tx_endpoints_.consume_all([](endpoint_wrapper& ep) { ep.cleanup(); });
-        rx_endpoints_.consume_all([](endpoint_wrapper& ep) { ep.cleanup(); });
+        tx_endpoints_.consume_all([](auto&& ep) { ep.cleanup(); });
+        rx_endpoints_.consume_all([](auto&& ep) { ep.cleanup(); });
 
         // No cleanup threadlocals : done by consume_all cleanup above
         // eps_->tl_tx_.endpoint_.cleanup();


### PR DESCRIPTION
Boost 1.87.0 changed the `consume_one` function (used by `consume_all`) to actually move arguments into the callback (https://github.com/boostorg/lockfree/commit/5e9bc81d9c1763861a03811266edb142b797987d, specifically this line: https://github.com/boostorg/lockfree/blob/5e9bc81d9c1763861a03811266edb142b797987d/include/boost/lockfree/queue.hpp#L537). This breaks compilation of the libfabric backend in oomph because the callback expects to receive the `endpoint_wrapper` by l-value reference.

This fixes compilation by using a universal reference `auto&&`. This allows taking the endpoint wrapper by reference in all cases. Using `endpoint_wrapper&&` would fix compilation with Boost 1.87.0, but break it with older versions. Taking it by value would also work with all versions, but introduces an extra move/copy construction. I do like explicitly naming types if possible, but in this case it seems worth the tradeoff to use `auto`.